### PR TITLE
Enhancements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
     ],
     "cSpell.words": [
         "jakemorrison",
+        "Pscx",
         "shortcode"
     ]
 }

--- a/docs/Add-EmojiToText.md
+++ b/docs/Add-EmojiToText.md
@@ -89,7 +89,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction. 
 For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -110,4 +110,3 @@ This function uses the Public data set from the Unicode Data Files and adheres t
 [https://pwshEmojiExplorer.readthedocs.io/en/latest/Add-EmojiToText/](https://pwshEmojiExplorer.readthedocs.io/en/latest/Add-EmojiToText/)
 
 [https://www.unicode.org/license.txt](https://www.unicode.org/license.txt)
-

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.4]
 
+- Module Changes
+    - Addressed bug where `Expand-XMLDataSet` can file if user has `Expand-Archive` from `Pscx` module, not from `Microsoft.PowerShell.Archive`
 - Build Updates
     - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script. This is to account for an issue in PowerShell `7.4.0`+ where a new parameter was introduced that platyPS can not handle during help creation. Ref: [platyPS issue]([text](https://github.com/PowerShell/platyPS/issues/595)).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.4]
 
 - Module Changes
-    - Addressed bug where `Expand-XMLDataSet` can file if user has `Expand-Archive` from `Pscx` module, not from `Microsoft.PowerShell.Archive`
+    - Addressed bug where `Expand-XMLDataSet` can fail if user has `Expand-Archive` from `Pscx` module, not from `Microsoft.PowerShell.Archive`
 - Build Updates
     - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script. This is to account for an issue in PowerShell `7.4.0`+ where a new parameter was introduced that platyPS can not handle during help creation. Ref: [platyPS issue]([text](https://github.com/PowerShell/platyPS/issues/595)).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.2.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4]
+
+- Build Updates
+    - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script. This is to account for an issue in PowerShell `7.4.0`+ where a new parameter was introduced that platyPS can not handle during help creation. Ref: [platyPS issue]([text](https://github.com/PowerShell/platyPS/issues/595)).
+
 ## [0.8.2]
 
 - Module Changes

--- a/docs/Get-AllEmoji.md
+++ b/docs/Get-AllEmoji.md
@@ -56,7 +56,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction. 
 For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -80,4 +80,3 @@ This function uses the Public data set from the Unicode Data Files and adheres t
 [https://pwshEmojiExplorer.readthedocs.io/en/latest/Get-AllEmoji/](https://pwshEmojiExplorer.readthedocs.io/en/latest/Get-AllEmoji/)
 
 [https://www.unicode.org/license.txt](https://www.unicode.org/license.txt)
-

--- a/docs/Get-Emoji.md
+++ b/docs/Get-Emoji.md
@@ -277,7 +277,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction. 
 For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -301,4 +301,3 @@ This function uses the Public data set from the Unicode Data Files and adheres t
 [https://pwshEmojiExplorer.readthedocs.io/en/latest/Get-Emoji/](https://pwshEmojiExplorer.readthedocs.io/en/latest/Get-Emoji/)
 
 [https://www.unicode.org/license.txt](https://www.unicode.org/license.txt)
-

--- a/docs/pwshEmojiExplorer.md
+++ b/docs/pwshEmojiExplorer.md
@@ -2,7 +2,7 @@
 Module Name: pwshEmojiExplorer
 Module Guid: 6e4813c7-6f30-42e8-adc4-b3d9b46bce9a
 Download Help Link: NA
-Help Version: 0.8.2
+Help Version: 0.8.4
 Locale: en-US
 ---
 

--- a/src/MarkdownRepair.ps1
+++ b/src/MarkdownRepair.ps1
@@ -1,0 +1,135 @@
+﻿<#
+.SYNOPSIS
+    Repair PlatyPS generated markdown files.
+.NOTES
+    This file is temporarily required to handle platyPS help generation.
+        https://github.com/PowerShell/platyPS/issues/595
+    This is a result of a breaking change introduced in PowerShell 7.4.0:
+        https://learn.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-74?view=powershell-7.4
+        Breaking Changes: Added the ProgressAction parameter to the Common Parameters
+    modified from source: https://github.com/PowerShell/platyPS/issues/595#issuecomment-1820971702
+#>
+
+function Remove-CommonParameterFromMarkdown {
+    <#
+    .SYNOPSIS
+        Remove a PlatyPS generated parameter block.
+    .DESCRIPTION
+        Removes parameter block for the provided parameter name from the markdown file provided.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    foreach ($p in $Path) {
+        $content = (Get-Content -Path $p -Raw).TrimEnd()
+        $updateFile = $false
+        foreach ($param in $ParameterName) {
+            if (-not ($Param.StartsWith('-'))) {
+                $param = "-$($param)"
+            }
+            # Remove the parameter block
+            $pattern = "(?m)^### $param\r?\n[\S\s]*?(?=#{2,3}?)"
+            $newContent = $content -replace $pattern, ''
+            # Remove the parameter from the syntax block
+            $pattern = " \[$param\s?.*?]"
+            $newContent = $newContent -replace $pattern, ''
+            if ($null -ne (Compare-Object -ReferenceObject $content -DifferenceObject $newContent)) {
+                Write-Verbose "Added $param to $p"
+                # Update file content
+                $content = $newContent
+                $updateFile = $true
+            }
+        }
+        # Save file if content has changed
+        if ($updateFile) {
+            $newContent | Out-File -Encoding utf8 -FilePath $p
+            Write-Verbose "Updated file: $p"
+        }
+    }
+    return
+}
+
+function Add-MissingCommonParameterToMarkdown {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    foreach ($p in $Path) {
+        $content = (Get-Content -Path $p -Raw).TrimEnd()
+        $updateFile = $false
+        foreach ($NewParameter in $ParameterName) {
+            if (-not ($NewParameter.StartsWith('-'))) {
+                $NewParameter = "-$($NewParameter)"
+            }
+            $pattern = '(?m)^This cmdlet supports the common parameters:(.+?)\.'
+            $replacement = {
+                $Params = $_.Groups[1].Captures[0].ToString() -split ' '
+                $CommonParameters = @()
+                foreach ($CommonParameter in $Params) {
+                    if ($CommonParameter.StartsWith('-')) {
+                        if ($CommonParameter.EndsWith(',')) {
+                            $CleanParam = $CommonParameter.Substring(0, $CommonParameter.Length - 1)
+                        }
+                        elseif ($p.EndsWith('.')) {
+                            $CleanParam = $CommonParameter.Substring(0, $CommonParameter.Length - 1)
+                        }
+                        else {
+                            $CleanParam = $CommonParameter
+                        }
+                        $CommonParameters += $CleanParam
+                    }
+                }
+                if ($NewParameter -notin $CommonParameters) {
+                    $CommonParameters += $NewParameter
+                }
+                $CommonParameters[-1] = "and $($CommonParameters[-1]). "
+                return "This cmdlet supports the common parameters: " + (($CommonParameters | Sort-Object) -join ', ')
+            }
+            $newContent = $content -replace $pattern, $replacement
+            if ($null -ne (Compare-Object -ReferenceObject $content -DifferenceObject $newContent)) {
+                Write-Verbose "Added $NewParameter to $p"
+                $updateFile = $true
+                $content = $newContent
+            }
+        }
+        # Save file if content has changed
+        if ($updateFile) {
+            $newContent | Out-File -Encoding utf8 -FilePath $p
+            Write-Verbose "Updated file: $p"
+        }
+    }
+    return
+}
+
+function Repair-PlatyPSMarkdown {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter()]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    $Parameters = @{
+        Path          = $Path
+        ParameterName = $ParameterName
+    }
+    $null = Remove-CommonParameterFromMarkdown @Parameters
+    $null = Add-MissingCommonParameterToMarkdown @Parameters
+    return
+}

--- a/src/pwshEmojiExplorer/Private/Expand-XMLDataSet.ps1
+++ b/src/pwshEmojiExplorer/Private/Expand-XMLDataSet.ps1
@@ -57,7 +57,7 @@ function Expand-XMLDataSet {
             ErrorAction     = 'Stop'
             Path            = '{0}/{1}' -f $script:dataPath, $script:dataFileZip
         }
-        $null = Expand-Archive @expandArchiveSplat
+        $null = Microsoft.PowerShell.Archive\Expand-Archive @expandArchiveSplat
         Write-Verbose -Message 'Expand completed.'
     } #try
     catch {

--- a/src/pwshEmojiExplorer/pwshEmojiExplorer.psd1
+++ b/src/pwshEmojiExplorer/pwshEmojiExplorer.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'pwshEmojiExplorer.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.8.2'
+    ModuleVersion     = '0.8.4'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
# Pull Request

## Issue

Fixes #2 

## Description

- Module Changes
    - Addressed bug where `Expand-XMLDataSet` can fail if user has `Expand-Archive` from `Pscx` module, not from `Microsoft.PowerShell.Archive`
- Build Updates
    - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script. This is to account for an issue in PowerShell `7.4.0`+ where a new parameter was introduced that platyPS can not handle during help creation. Ref: [platyPS issue]([text](https://github.com/PowerShell/platyPS/issues/595)).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
