### PR TITLE
Enhancements

### DIFF
--- a/CodeBuild/UnitTestAndBuild/Validate-CFNTemplates.Tests.ps1
+++ b/CodeBuild/UnitTestAndBuild/Validate-CFNTemplates.Tests.ps1
@@ -7,7 +7,7 @@ $ErrorActionPreference = 'Stop'
 Describe 'CloudFormation Template Validation' {
 
     Context -Name 'CloudFormation Templates' {
-        Context -Name '<_.Name>' -Foreach $files {
+        Context -Name '<_.Name>' -ForEach $files {
             It 'is valid CFN' {
                 { Test-CFNTemplate -TemplateBody (Get-Content -Path $_.FullName -Raw) } | Should -Not -Throw
             } #it

--- a/CodeBuild/UnitTestAndBuild/Validate-JSONConfigurations.Tests.ps1
+++ b/CodeBuild/UnitTestAndBuild/Validate-JSONConfigurations.Tests.ps1
@@ -7,7 +7,7 @@ $ErrorActionPreference = 'Stop'
 Describe -Name 'JSON Configuration File Validation' {
 
     Context -Name 'JSON Parameter Files' {
-        Context -Name '<_.Name>' -Foreach $files {
+        Context -Name '<_.Name>' -ForEach $files {
             It 'is valid JSON' {
                 { $null = ConvertFrom-Json -InputObject (Get-Content -Path $_.FullName -Raw) } | Should -Not -Throw
             } #it

--- a/CodeBuild/UnitTestAndBuild/dotnet-install.ps1
+++ b/CodeBuild/UnitTestAndBuild/dotnet-install.ps1
@@ -520,7 +520,7 @@ function Get-Version-From-LatestVersion-File([string]$AzureFeed, [string]$Channe
 function Parse-Jsonfile-For-Version([string]$JSonFile) {
     Say-Invocation $MyInvocation
 
-    If (-Not (Test-Path $JSonFile)) {
+    if (-not (Test-Path $JSonFile)) {
         throw "Unable to find '$JSonFile'"
     }
     try {
@@ -548,7 +548,7 @@ function Parse-Jsonfile-For-Version([string]$JSonFile) {
     else {
         throw "Unable to find the SDK node in '$JSonFile'"
     }
-    If ($Version -eq $null) {
+    if ($Version -eq $null) {
         throw "Unable to find the SDK:version node in '$JSonFile'"
     }
     return $Version
@@ -631,7 +631,7 @@ function Get-Product-Version([string]$AzureFeed, [string]$SpecificVersion, [stri
     (Get-Product-Version-Url $AzureFeed $SpecificVersion $PackageDownloadLink -Flattened $true),
     (Get-Product-Version-Url $AzureFeed $SpecificVersion $PackageDownloadLink -Flattened $false)
 
-    Foreach ($ProductVersionTxtURL in $ProductVersionTxtURLs) {
+    foreach ($ProductVersionTxtURL in $ProductVersionTxtURLs) {
         Say-Verbose "Checking for the existence of $ProductVersionTxtURL"
 
         try {
@@ -784,7 +784,7 @@ function Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package([Sys
         $dir = Get-Path-Prefix-With-Version $entry.FullName
         if ($null -ne $dir) {
             $path = Get-Absolute-Path $(Join-Path -Path $OutPath -ChildPath $dir)
-            if (-Not (Test-Path $path -PathType Container)) {
+            if (-not (Test-Path $path -PathType Container)) {
                 $ret += $dir
             }
         }
@@ -823,11 +823,11 @@ function Extract-Dotnet-Package([string]$ZipPath, [string]$OutPath) {
 
         foreach ($entry in $Zip.Entries) {
             $PathWithVersion = Get-Path-Prefix-With-Version $entry.FullName
-            if (($null -eq $PathWithVersion) -Or ($DirectoriesToUnpack -contains $PathWithVersion)) {
+            if (($null -eq $PathWithVersion) -or ($DirectoriesToUnpack -contains $PathWithVersion)) {
                 $DestinationPath = Get-Absolute-Path $(Join-Path -Path $OutPath -ChildPath $entry.FullName)
                 $DestinationDir = Split-Path -Parent $DestinationPath
-                $OverrideFiles = $OverrideNonVersionedFiles -Or (-Not (Test-Path $DestinationPath))
-                if ((-Not $DestinationPath.EndsWith("\")) -And $OverrideFiles) {
+                $OverrideFiles = $OverrideNonVersionedFiles -or (-not (Test-Path $DestinationPath))
+                if ((-not $DestinationPath.EndsWith("\")) -and $OverrideFiles) {
                     New-Item -ItemType Directory -Force -Path $DestinationDir | Out-Null
                     [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $DestinationPath, $OverrideNonVersionedFiles)
                 }
@@ -887,9 +887,9 @@ function SafeRemoveFile($Path) {
 
 function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot) {
     $BinPath = Get-Absolute-Path $(Join-Path -Path $InstallRoot -ChildPath "")
-    if (-Not $NoPath) {
+    if (-not $NoPath) {
         $SuffixedBinPath = "$BinPath;"
-        if (-Not $env:path.Contains($SuffixedBinPath)) {
+        if (-not $env:path.Contains($SuffixedBinPath)) {
             Say "Adding to current process PATH: `"$BinPath`". Note: This change will not be visible if PowerShell was run as a child process."
             $env:path = $SuffixedBinPath + $env:path
         }
@@ -1138,7 +1138,7 @@ if ([string]::IsNullOrEmpty($JSonFile) -and ($Version -eq "latest")) {
         $DownloadLinks += New-Object PSObject -Property @{downloadLink = "$DownloadLink"; specificVersion = "$SpecificVersion"; effectiveVersion = "$EffectiveVersion"; type = 'aka.ms' }
         Say-Verbose "Generated aka.ms link $DownloadLink with version $EffectiveVersion"
 
-        if (-Not $DryRun) {
+        if (-not $DryRun) {
             Say-Verbose "Checking if the version $EffectiveVersion is already installed"
             if (Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $EffectiveVersion) {
                 Say "$assetName with version '$EffectiveVersion' is already installed."
@@ -1166,7 +1166,7 @@ if ([string]::IsNullOrEmpty($NormalizedQuality) -and 0 -eq $DownloadLinks.count)
                 Say-Verbose "Generated legacy link $LegacyDownloadLink with version $EffectiveVersion"
             }
 
-            if (-Not $DryRun) {
+            if (-not $DryRun) {
                 Say-Verbose "Checking if the version $EffectiveVersion is already installed"
                 if (Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $EffectiveVersion) {
                     Say "$assetName with version '$EffectiveVersion' is already installed."
@@ -1247,7 +1247,7 @@ Extract-Dotnet-Package -ZipPath $ZipPath -OutPath $InstallRoot
 $isAssetInstalled = $false
 
 # if the version contains "RTM" or "servicing"; check if a 'release-type' SDK version is installed.
-if ($DownloadedLink.effectiveVersion -Match "rtm" -or $DownloadedLink.effectiveVersion -Match "servicing") {
+if ($DownloadedLink.effectiveVersion -match "rtm" -or $DownloadedLink.effectiveVersion -match "servicing") {
     $ReleaseVersion = $DownloadedLink.effectiveVersion.Split("-")[0]
     Say-Verbose "Checking installation: version = $ReleaseVersion"
     $isAssetInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $ReleaseVersion

--- a/CodeBuild/UnitTestAndBuild/dotnet-install.ps1
+++ b/CodeBuild/UnitTestAndBuild/dotnet-install.ps1
@@ -211,19 +211,19 @@ function Get-CLIArchitecture-From-Architecture([string]$Architecture) {
 
     switch ($Architecture.ToLowerInvariant()) {
         { ($_ -eq "amd64") -or ($_ -eq "x64") } {
-            return "x64" 
+            return "x64"
         }
         { $_ -eq "x86" } {
-            return "x86" 
+            return "x86"
         }
         { $_ -eq "arm" } {
-            return "arm" 
+            return "arm"
         }
         { $_ -eq "arm64" } {
-            return "arm64" 
+            return "arm64"
         }
         default {
-            throw "Architecture '$Architecture' not supported. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues" 
+            throw "Architecture '$Architecture' not supported. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues"
         }
     }
 }
@@ -256,14 +256,14 @@ function Get-NormalizedQuality([string]$Quality) {
 
     switch ($Quality) {
         { @("daily", "signed", "validated", "preview") -contains $_ } {
-            return $Quality.ToLowerInvariant() 
+            return $Quality.ToLowerInvariant()
         }
         #ga quality is available without specifying quality, so normalizing it to empty
         { $_ -eq "ga" } {
-            return "" 
+            return ""
         }
         default {
-            throw "'$Quality' is not a supported value for -Quality option. Supported values are: daily, signed, validated, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues." 
+            throw "'$Quality' is not a supported value for -Quality option. Supported values are: daily, signed, validated, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues."
         }
     }
 }
@@ -281,13 +281,13 @@ function Get-NormalizedChannel([string]$Channel) {
 
     switch ($Channel) {
         { $_ -eq "lts" } {
-            return "LTS" 
+            return "LTS"
         }
         { $_ -eq "current" } {
-            return "current" 
+            return "current"
         }
         default {
-            return $Channel.ToLowerInvariant() 
+            return $Channel.ToLowerInvariant()
         }
     }
 }
@@ -297,19 +297,19 @@ function Get-NormalizedProduct([string]$Runtime) {
 
     switch ($Runtime) {
         { $_ -eq "dotnet" } {
-            return "dotnet-runtime" 
+            return "dotnet-runtime"
         }
         { $_ -eq "aspnetcore" } {
-            return "aspnetcore-runtime" 
+            return "aspnetcore-runtime"
         }
         { $_ -eq "windowsdesktop" } {
-            return "windowsdesktop-runtime" 
+            return "windowsdesktop-runtime"
         }
         { [string]::IsNullOrEmpty($_) } {
-            return "dotnet-sdk" 
+            return "dotnet-sdk"
         }
         default {
-            throw "'$Runtime' is not a supported value for -Runtime option, supported values are: dotnet, aspnetcore, windowsdesktop. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues." 
+            throw "'$Runtime' is not a supported value for -Runtime option, supported values are: dotnet, aspnetcore, windowsdesktop. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues."
         }
     }
 }
@@ -328,7 +328,7 @@ function Get-Version-From-LatestVersion-File-Content([string]$VersionText) {
 
     $VersionInfo = @{
         CommitHash = $(if ($Data.Count -gt 1) {
-                $Data[0] 
+                $Data[0]
             })
         Version    = $Data[-1] # last line is always the version number.
     }
@@ -499,16 +499,16 @@ function Get-Version-From-LatestVersion-File([string]$AzureFeed, [string]$Channe
 
     switch ($Response.Content.Headers.ContentType) {
         { ($_ -eq "application/octet-stream") } {
-            $VersionText = $StringContent 
+            $VersionText = $StringContent
         }
         { ($_ -eq "text/plain") } {
-            $VersionText = $StringContent 
+            $VersionText = $StringContent
         }
         { ($_ -eq "text/plain; charset=UTF-8") } {
-            $VersionText = $StringContent 
+            $VersionText = $StringContent
         }
         default {
-            throw "``$Response.Content.Headers.ContentType`` is an unknown .version file content type." 
+            throw "``$Response.Content.Headers.ContentType`` is an unknown .version file content type."
         }
     }
 
@@ -627,8 +627,9 @@ function Get-Product-Version([string]$AzureFeed, [string]$SpecificVersion, [stri
     Say-Invocation $MyInvocation
 
     # Try to get the version number, using the productVersion.txt file located next to the installer file.
-    $ProductVersionTxtURLs = (Get-Product-Version-Url $AzureFeed $SpecificVersion $PackageDownloadLink -Flattened $true),
-                             (Get-Product-Version-Url $AzureFeed $SpecificVersion $PackageDownloadLink -Flattened $false)
+    $ProductVersionTxtURLs =
+    (Get-Product-Version-Url $AzureFeed $SpecificVersion $PackageDownloadLink -Flattened $true),
+    (Get-Product-Version-Url $AzureFeed $SpecificVersion $PackageDownloadLink -Flattened $false)
 
     Foreach ($ProductVersionTxtURL in $ProductVersionTxtURLs) {
         Say-Verbose "Checking for the existence of $ProductVersionTxtURL"

--- a/src/Tests/Integration/pwshEmojiExplorer-Integration.Tests.ps1
+++ b/src/Tests/Integration/pwshEmojiExplorer-Integration.Tests.ps1
@@ -3947,7 +3947,7 @@ InModuleScope 'pwshEmojiExplorer' {
             It 'should return all emoji' {
                 # https://github.com/pester/Pester/issues/1315
                 $emojis = Get-AllEmoji
-            ($emojis[0]).GetType().Name | Should -Be 'PSEmoji'
+                ($emojis[0]).GetType().Name | Should -Be 'PSEmoji'
                 $emojis.Count | Should -BeGreaterThan 3000
             } #it
 
@@ -3960,7 +3960,7 @@ InModuleScope 'pwshEmojiExplorer' {
                 It 'should return the expected object type' {
                     # https://github.com/pester/Pester/issues/1315
                     $emoji = Get-Emoji -Emoji '😀'
-                ($emoji).GetType().Name | Should -Be 'PSEmoji'
+                    ($emoji).GetType().Name | Should -Be 'PSEmoji'
                 } #it
 
                 It 'should return the expected results for Emoji' {

--- a/src/Tests/Unit/Private/Import-XMLDataSet.Tests.ps1
+++ b/src/Tests/Unit/Private/Import-XMLDataSet.Tests.ps1
@@ -658,9 +658,6 @@ InModuleScope 'pwshEmojiExplorer' {
             Mock -CommandName Get-Content -MockWith {
                 $xmlData
             } #endMock
-            Mock -CommandName ConvertFrom-Clixml -MockWith {
-                $objData
-            } #endMock
         } #before_each
 
         Context 'Error' {

--- a/src/Tests/Unit/pwshEmojiExplorer-Module.Tests.ps1
+++ b/src/Tests/Unit/pwshEmojiExplorer-Module.Tests.ps1
@@ -19,8 +19,7 @@ Describe 'Module Tests' -Tag Unit {
             $? | Should -BeTrue
         } #psm1Exists
         It 'manifest should contain pwshEmojiExplorer.psm1' {
-            $PathToManifest |
-            Should -FileContentMatchExactly "pwshEmojiExplorer.psm1"
+            $PathToManifest | Should -FileContentMatchExactly "pwshEmojiExplorer.psm1"
         } #validPSM1
         It 'should have a matching module name in the manifest' {
             $script:manifestEval.Name | Should -BeExactly $ModuleName

--- a/src/pwshEmojiExplorer.build.ps1
+++ b/src/pwshEmojiExplorer.build.ps1
@@ -447,8 +447,8 @@ Add-BuildTask UpdateCBH -After AssetCopy {
     Get-ChildItem -Path "$script:ArtifactsPath\Public\*.ps1" -File | ForEach-Object {
         $FormattedOutFile = $_.FullName
         Write-Output "      Replacing CBH in file: $($FormattedOutFile)"
-        $UpdatedFile = (Get-Content  $FormattedOutFile -raw) -replace $CBHPattern, $ExternalHelp
-        $UpdatedFile | Out-File -FilePath $FormattedOutFile -force -Encoding:utf8
+        $UpdatedFile = (Get-Content  $FormattedOutFile -Raw) -replace $CBHPattern, $ExternalHelp
+        $UpdatedFile | Out-File -FilePath $FormattedOutFile -Force -Encoding:utf8
     }
 } #UpdateCBH
 

--- a/src/pwshEmojiExplorer/Private/Import-XMLDataSet.ps1
+++ b/src/pwshEmojiExplorer/Private/Import-XMLDataSet.ps1
@@ -31,8 +31,17 @@ function Import-XMLDataSet {
                     Raw         = $true
                     ErrorAction = 'Stop'
                 }
-                $fileData = Get-Content @getContentSplat
-                $script:glData = $fileData | ConvertFrom-Clixml -ErrorAction Stop
+                $fileData = Get-Content @getContentSplat | ForEach-Object {
+                    try {
+                        foreach ($record in ($_ -split '(?<!^)(?=<Objs)')) {
+                            [System.Management.Automation.PSSerializer]::Deserialize($record)
+                        }
+                    }
+                    catch {
+                        Write-Error -ErrorRecord $_ -ErrorAction Stop
+                    }
+                }
+                $script:glData = $fileData
             } #try
             catch {
                 $result = $false

--- a/src/pwshEmojiExplorer/Private/Invoke-XMLDataCheck.ps1
+++ b/src/pwshEmojiExplorer/Private/Invoke-XMLDataCheck.ps1
@@ -25,7 +25,7 @@ function Invoke-XMLDataCheck {
             HelpMessage = 'Skip confirmation')]
         [switch]$Force
     )
-    Begin {
+    begin {
 
         if (-not $PSBoundParameters.ContainsKey('Verbose')) {
             $VerbosePreference = $PSCmdlet.SessionState.PSVariable.GetValue('VerbosePreference')
@@ -41,7 +41,7 @@ function Invoke-XMLDataCheck {
 
         $results = $true #assume the best
     } #begin
-    Process {
+    process {
         # -Confirm --> $ConfirmPreference = 'Low'
         # ShouldProcess intercepts WhatIf* --> no need to pass it on
         if ($Force -or $PSCmdlet.ShouldProcess("ShouldProcess?")) {
@@ -76,7 +76,7 @@ function Invoke-XMLDataCheck {
 
         } #if_Should
     } #process
-    End {
+    end {
         return $results
     } #end
 } #Invoke-XMLDataCheck

--- a/src/pwshEmojiExplorer/pwshEmojiExplorer.psd1
+++ b/src/pwshEmojiExplorer/pwshEmojiExplorer.psd1
@@ -51,12 +51,7 @@
     # ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules   = @(
-        @{
-            ModuleName    = 'Convert'
-            ModuleVersion = '1.5.0'
-        }
-    )
+    # RequiredModules   = @()
 
     # Assemblies that must be loaded prior to importing this module
     # RequiredAssemblies = @()


### PR DESCRIPTION
# Pull Request

I have successfully removed the dependency on the Convert module entirely. It turned out to require a very small number of changes in the project. Additionally, I also fixed some errors reported by PSScriptAnalyzer—without these fixes, I couldn't build the project.

I built and test the project as follows:
Installed InvokeBuild (version 5.14.22)
Installed PSScriptAnalyzer (version 1.24.0)
Installed platyPS (version 0.12)

Then, from the src directory, I ran Invoke-Build.
All tests passed successfully.

## Issue

[Issue #5: Install-Module pwshEmojiExplorer requires accepting -AllowClobber](https://github.com/techthoughts2/pwshEmojiExplorer/issues/5)

## Description

Removed dependency from Convert module.
Fixed some warnings of PSScriptAnalyzer to build and test project before creating this PR.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
